### PR TITLE
For crosswalk it handles "fake" visibility differently

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "com.geotab.BackgroundWatchPosition",
+  "version": "0.0.1",
+  "description": "Persist watchPosition in background even on Android System WebView",
+  "cordova": {
+    "id": "com.geotab.BackgroundWatchPosition",
+    "platforms": [
+      "android"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Geotab/cordova-background-watchposition.git"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-android"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Mike Murkovic",
+  "license": "Proprietary",
+  "bugs": {
+    "url": "https://github.com/Geotab/cordova-background-watchposition/issues"
+  },
+  "homepage": "https://github.com/Geotab/cordova-background-watchposition#readme"
+}

--- a/src/android/com/geotab/BackgroundWatchPosition.java
+++ b/src/android/com/geotab/BackgroundWatchPosition.java
@@ -32,7 +32,7 @@ public class BackgroundWatchPosition extends CordovaPlugin {
             public void run() {
               try {
                 Class.forName("org.crosswalk.engine.XWalkCordovaView");
-                ((XWalkCordovaView)webView.getEngine().getView()).onShow();
+                ((org.crosswalk.engine.XWalkCordovaView)webView.getEngine().getView()).onShow();
               } catch (ClassNotFoundException e){
                 webView.getEngine().getView().dispatchWindowVisibilityChanged(View.VISIBLE);
               }

--- a/src/android/com/geotab/BackgroundWatchPosition.java
+++ b/src/android/com/geotab/BackgroundWatchPosition.java
@@ -27,7 +27,17 @@ public class BackgroundWatchPosition extends CordovaPlugin {
       public void run() {
         try {
           Thread.sleep(1000);
-          webView.getEngine().getView().dispatchWindowVisibilityChanged(View.VISIBLE);
+          cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              try {
+                Class.forName("org.crosswalk.engine.XWalkCordovaView");
+                ((XWalkCordovaView)webView.getEngine().getView()).onShow();
+              } catch (ClassNotFoundException e){
+                webView.getEngine().getView().dispatchWindowVisibilityChanged(View.VISIBLE);
+              }
+            }
+          });
         } catch (InterruptedException e) {
           // do nothing
         }


### PR DESCRIPTION
Need to use the onShow() method instead of dispatchWindowVisibilityChanged. The second method
was not followed at all inside xwalk.
